### PR TITLE
Make homepage fit on mobile

### DIFF
--- a/source/pug/partials/pulse-projects.pug
+++ b/source/pug/partials/pulse-projects.pug
@@ -1,7 +1,7 @@
 mixin projects(projectData, includeJSON)
   - let json = includeJSON ? projectData : false
 
-  .row.mb-5.pulse-projects(data-json=json)
+  .mb-5.pulse-projects(data-json=json)
     each project, index in projectData
       +project(projectData[index])
 


### PR DESCRIPTION
The projects section was too wide for its container on mobile. Discovered this was part of the issue on #134; but that problem persists on other pages due to extra words in the nav.