### PR TITLE
Remove font-size override in "more details" button

### DIFF
--- a/source/js/components/people/people.scss
+++ b/source/js/components/people/people.scss
@@ -11,7 +11,6 @@
     .more-details {
       background-color: $mobile-blue;
       color: white;
-      font-size: 12px;
 
       &:hover {
         background-color: #0081ad;


### PR DESCRIPTION
This change allows ".btn-sm" to determine the font size, fixing the top spacing issue in Featured Cards.
<img width="774" alt="image" src="https://cloud.githubusercontent.com/assets/22157921/25396833/f457adcc-299a-11e7-8dcb-c57e31f55f76.png">
