### PR TITLE
Changed line height of "@mixin black-box-white-text". 

### DIFF
--- a/source/sass/type.scss
+++ b/source/sass/type.scss
@@ -38,7 +38,7 @@ a {
   color: $white;
   display: inline;
   padding: 0.1em;
-  line-height: 1.333;
+  line-height: 1.5;
 }
 
 .h1-home-white {


### PR DESCRIPTION
This change affected ".h1-white" and ".h1-home-white".

You know it worked if you see the gap between the 2 black boxes (in all headings) like in this example below:
<img width="435" alt="image" src="https://cloud.githubusercontent.com/assets/22157921/25685110/1015012e-301a-11e7-948c-cad3d282b16c.png">
