### PR TITLE
Added 3 links to Support page (Grants section): 

### DIFF
--- a/source/pug/views/support.pug
+++ b/source/pug/views/support.pug
@@ -50,7 +50,9 @@ block content
         p We provide funding to promising people and big ideas. Our grants support gigabit technology laboratories, critical studies in emerging markets and more.
         ul
           li.mb-3: a.cta-link(href=`https://learning.mozilla.org/en-US/gigabit/apply`) Apply for Gigabit grant 2017
-          li.mb-3: a.cta-link(href=`http://hivechicago.org/portfolio/#/*`) See grant project examples (NYC/Chicago)
+          li.mb-3: a.cta-link(href=`http://hivenyc.org/portfolio/#/*`) See funded project examples from Hive NYC
+          li.mb-3: a.cta-link(href=`http://hivechicago.org/portfolio/#/*`) See funded project examples from Hive Chicago
+          li.mb-3: a.cta-link(href=`http://hivetoronto.org/portfolio/#/*`) See funded project examples from Hive Toronto
 
     .row.mb-5
       .col-md-6

--- a/source/pug/views/support.pug
+++ b/source/pug/views/support.pug
@@ -50,9 +50,9 @@ block content
         p We provide funding to promising people and big ideas. Our grants support gigabit technology laboratories, critical studies in emerging markets and more.
         ul
           li.mb-3: a.cta-link(href=`https://learning.mozilla.org/en-US/gigabit/apply`) Apply for Gigabit grant 2017
-          li.mb-3: a.cta-link(href=`http://hivenyc.org/portfolio/#/*`) See funded project examples from Hive NYC
-          li.mb-3: a.cta-link(href=`http://hivechicago.org/portfolio/#/*`) See funded project examples from Hive Chicago
-          li.mb-3: a.cta-link(href=`http://hivetoronto.org/portfolio/#/*`) See funded project examples from Hive Toronto
+          li.mb-3: a.cta-link(href=`http://hivenyc.org/portfolio/#/*`) See Hive NYC funded projects
+          li.mb-3: a.cta-link(href=`http://hivechicago.org/portfolio/#/*`) See Hive Chicago funded projects
+          li.mb-3: a.cta-link(href=`http://hivetoronto.org/portfolio/#/*`) See Hive Toronto funded projects
 
     .row.mb-5
       .col-md-6


### PR DESCRIPTION
Added 3 links to Support page (Grants section): 
See funded project examples from Hive NYC, See funded project examples from Hive Chicago, and See funded project examples from Hive Toronto.

New section should look like that:
<img width="630" alt="image" src="https://cloud.githubusercontent.com/assets/22157921/25728638/3013c69c-30e5-11e7-84f2-beb0a57cb54a.png">

Fixes #395 

