### PR TITLE
Update Mozfest date in Upcoming Page

### DIFF
--- a/source/json/upcoming.json
+++ b/source/json/upcoming.json
@@ -56,7 +56,7 @@
   },
   {
     "photo": "/_images/upcoming/mozfest.jpg",
-    "startDate": "2017-11-01T07:00:00.000Z",
+    "startDate": "2017-10-01T07:00:00.000Z",
     "endDate": null,
     "headline": "MozFest",
     "description": "The world's leading festival for the open Internet movement. Held annually, MozFest features hands-on workshops, keynotes, hackathons and science fairs.",


### PR DESCRIPTION
We should see "October 2017" now instead of "November 2017"

<img width="614" alt="image" src="https://cloud.githubusercontent.com/assets/22157921/25729410/0b8699e4-30ea-11e7-9073-c94c2b38c963.png">

Fixes:  #397

