### PR TITLE
Revert takeover button to fixed, not sticky

### DIFF
--- a/source/js/components/takeover/takeover.scss
+++ b/source/js/components/takeover/takeover.scss
@@ -15,7 +15,7 @@
   }
 
   .button-group {
-    position: sticky;
+    position: fixed;
     bottom: 0;
     left: 0;
     background: $white;


### PR DESCRIPTION
Bug in iOS makes buttons untappable

To see bug: Open page for first time (or in private browsing mode) in Safari on an iPhone. The browser chrome at the bottom will be stuck over the buttons users need to tap to access the site.