### PR TITLE
Wire up homepage highlights to static JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "server": "live-server ./dest --port=2017 --entry-file=errors/404/index.html",
     "start": "npm i && npm run build-uncompressed && run-p server watch:**",
     "test:eslint": "eslint --config ./.eslintrc.yaml scripts/**/*.js source/js/**/*.js source/js/components/**/*.jsx",
-    "test:json": "ajv validate -s source/json/upcoming.schema.json -d source/json/upcoming.json",
+    "test:json": "ajv validate -s source/json/upcoming.schema.json -d source/json/upcoming.json && ajv validate -s source/json/highlights.schema.json -d source/json/highlights.json",
     "test:pulled-json": "ajv validate -s source/json/people.schema.json -d source/json/temp/people.json && ajv validate -s source/json/news.schema.json -d source/json/temp/news.json",
     "test:pug": "pug-lint source/pug/**/*.pug",
     "test:scss": "stylelint 'source/sass/main.scss' --syntax scss",

--- a/scripts/build-pug.js
+++ b/scripts/build-pug.js
@@ -30,8 +30,8 @@ function buildPage(template, target, extraData) {
 
 buildPage(`home`, `/`, {
   news: JSON.parse((shelljs.cat(`source/json/temp/news.json`).toString())),
-  project: JSON.parse((shelljs.cat(`source/json/temp/pulse-homepage.json`).toString())),
-  people: JSON.parse((shelljs.cat(`source/json/temp/people.json`).toString()))
+  people: JSON.parse((shelljs.cat(`source/json/temp/people.json`).toString())),
+  highlights: JSON.parse((shelljs.cat(`source/json/highlights.json`).toString()))
 });
 buildPage(`people`, `/people`, JSON.parse((shelljs.cat(`source/json/temp/people.json`).toString())));
 buildPage(`get-involved`, `/get-involved`);

--- a/scripts/fetch-json.js
+++ b/scripts/fetch-json.js
@@ -20,7 +20,6 @@ let fetchJSON = (shortName, source) => {
   });
 };
 
-fetchJSON(`pulse-homepage`, `https://${environment[`PULSE_API_DOMAIN`]}/entries/217`);
 fetchJSON(`pulse-privacy`, `https://${environment[`PULSE_API_DOMAIN`]}/entries/?issue=Online%20Privacy%20%26%20Security&featured=True&ordering=-created`);
 fetchJSON(`pulse-innovation`, `https://${environment[`PULSE_API_DOMAIN`]}/entries/?issue=Open%20Innovation&featured=True&ordering=-created`);
 fetchJSON(`pulse-inclusion`, `https://${environment[`PULSE_API_DOMAIN`]}/entries/?issue=Digital%20Inclusion&featured=True&ordering=-created`);

--- a/source/json/highlights.json
+++ b/source/json/highlights.json
@@ -1,0 +1,26 @@
+[
+  {
+    "title": "Mozilla Global Sprint",
+    "image": "https://assets.mofoprod.net/network-pulse/images/entries/2017-04-17_195731.4603530000.png",
+    "description": "Mozilla’s Global Sprint is a fun, fast-paced and two-day collaborative event to hack and build projects for a healthy Internet. A diverse network of scientists, educators, artists, engineers and others come together in person and online to innovate in the open.",
+    "link": "https://mozilla.github.io/global-sprint/",
+    "linkLabel": "Join This Project",
+    "footer": "<a class=\"btn btn-ghost\" href=\"/projects\">See More Projects</a>"
+  },
+  {
+    "title": "Internet Health Report",
+    "image": "http://via.placeholder.com/600x300",
+    "description": "Is the Internet getting healthier? Is it under threat? Do we all have a voice on the web? Mozilla’s Internet Health Report is an open source initiative that combines research from multiple sources to document what’s healthy and unhealthy.",
+    "link": "/opportunity/internet-health-report",
+    "linkLabel": "Read The Report",
+    "footer": null
+  },
+  {
+    "title": "Fellowships that Empower Leaders",
+    "image": "http://via.placeholder.com/600x300",
+    "description": "We provide funding and exciting project-based opportunities to professionals doing game-changing work at the intersection of media, science, security, advocacy, and technology.",
+    "link": "http://127.0.0.1:2017/opportunity/fellowships",
+    "linkLabel": "Be A Fellow",
+    "footer": null
+  }
+]

--- a/source/json/highlights.schema.json
+++ b/source/json/highlights.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {},
+  "id": "http://example.com/example.json",
+  "items": {
+    "id": "/items",
+    "properties": {
+      "description": {
+        "id": "/items/properties/description",
+        "type": "string"
+      },
+      "footer": {
+        "id": "/items/properties/footer",
+        "type": "string"
+      },
+      "image": {
+        "id": "/items/properties/image",
+        "type": "string"
+      },
+      "link": {
+        "id": "/items/properties/link",
+        "type": "string"
+      },
+      "linkLabel": {
+        "id": "/items/properties/linkLabel",
+        "type": "string"
+      },
+      "title": {
+        "id": "/items/properties/title",
+        "type": "string"
+      }
+    },
+    "required": [
+      "description",
+      "image",
+      "title",
+      "linkLabel",
+      "link"
+    ],
+    "type": "object"
+  },
+  "type": "array"
+}

--- a/source/json/highlights.schema.json
+++ b/source/json/highlights.schema.json
@@ -10,6 +10,7 @@
         "type": "string"
       },
       "footer": {
+        "description": "Text or HTML",
         "id": "/items/properties/footer",
         "type": [
           "string",

--- a/source/json/highlights.schema.json
+++ b/source/json/highlights.schema.json
@@ -11,7 +11,10 @@
       },
       "footer": {
         "id": "/items/properties/footer",
-        "type": "string"
+        "type": [
+          "string",
+          "null"
+        ]
       },
       "image": {
         "id": "/items/properties/image",

--- a/source/pug/views/home.pug
+++ b/source/pug/views/home.pug
@@ -32,6 +32,11 @@ mixin newsItem(data, featured=false)
       p.italic-black.mb-1 by #{data.author}
     p.small-gray=moment(data.date, `YYYY-MM-DD`).format(`MMMM YYYY`)
 
+mixin highlight(item)
+  h5.h4-light-black=item.title
+  p.body-black=item.description
+  a.cta-link(href=item.link)=item.linkLabel
+
 block heroGuts
   .row
     .col-md-12.col-lg-9.col-xl-8.py-5.px-4
@@ -103,19 +108,16 @@ block content
     .row
       .col-xs-12.col-md-6.mb-5
         .item-featured.pb-5.px-4.mt-4
-          img.key-item.mb-4(src=`${data.project.thumbnail}`)
-          h5.h4-light-black=`${data.project.title}`
-          p.body-black=`${data.project.description}`
-          a.cta-link(href=`${data.project.get_involved_url}`) Join this Project
-          .mt-5
-            a.btn.btn-ghost(href=`${env[`VIRTUAL_ROOT`]}projects`) See More Projects
+          img.key-item.mb-4(src=`${data.highlights[0].image}`)
+          h5.h4-light-black=`${data.highlights[0].title}`
+          p.body-black=`${data.highlights[0].description}`
+          a.cta-link(href=`${data.highlights[0].link}`)=data.highlights[0].linkLabel
+          .mt-5!=data.highlights[0].footer
+
       .col-md-6.mb-5
-        h5.h4-light-black Internet Health Report
-        p.body-black Is the Internet getting healthier? Is it under threat? Do we all have a voice on the web? Mozilla’s Internet Health Report is an open source initiative that combines research from multiple sources to document what’s healthy and unhealthy.
-        a.cta-link(href=`${env[`VIRTUAL_ROOT`]}opportunity/internet-health-report`) Read the report
-        hr
-        h5.h4-light-black Fellowships that Empower Leaders
-        p.body-black We provide funding and exciting project-based opportunities to professionals doing game-changing work at the intersection of media, science, security, advocacy, and technology.
-        a.cta-link(href=`${env[`VIRTUAL_ROOT`]}opportunity/fellowships`) Be a fellow
+        - for (let i = 1; i < data.highlights.length; i++)
+          +highlight(data.highlights[i])
+          - if (i !== data.highlights.length - 1)
+            hr
 
     .join-us.full-width.col.mb-5


### PR DESCRIPTION
This sets us up for moving the "highlights" into Mezzanine.

Once this lands we can then add this model and switch to `network-api` as the source of the JSON instead of the flat static version.

Related to #203 