### PR TITLE
switch to "auto" for scrollbars

### DIFF
--- a/source/js/components/nav/nav.scss
+++ b/source/js/components/nav/nav.scss
@@ -4,7 +4,7 @@
   height: 100%;
   width: 100%;
   z-index: 99999;
-  overflow: scroll;
+  overflow: auto;
 
   a {
     color: rgba(255, 255, 255, 0.75);


### PR DESCRIPTION
fixes https://github.com/mozilla/network/issues/386

With "scroll", the menu always has horizontal and vertical scrollbars (particularly visible on windows, or on a mac with a 3rd party mouse plugged in), even when the content fits on the screen. This change effects scrollbars only when necessary.