### PR TITLE
removes Hive Learning Networks link

### DIFF
--- a/source/pug/views/get-involved.pug
+++ b/source/pug/views/get-involved.pug
@@ -63,7 +63,6 @@ block content
         ul
           li.mb-3: a.cta-link(href=`https://learning.mozilla.org/gigabit`) Mozilla Gigabit cities
           li.mb-3: a.cta-link(href=`https://learning.mozilla.org/en-US/clubs`) Mozilla clubs
-          li.mb-3: a.cta-link(href=`https://hivelearningnetworks.org/`) Hive Learning Networks
           li.mb-3: a.cta-link(href=`https://science.mozilla.org/programs/studygroups`) Mozilla Science Study Groups
 
     .row.mb-5


### PR DESCRIPTION
fixes #634 

Removes Hive link from Local Organizing section of Get Involved page