### PR TITLE
Add in env-controllable CSP settings

### DIFF
--- a/network-api/app/networkapi/settings.py
+++ b/network-api/app/networkapi/settings.py
@@ -361,7 +361,6 @@ else:
 CSP_DEFAULT = (
     'self',
     'localhost:8000',
-    'test.example.com:8000',
 )
 
 CSP_DEFAULT_SRC = env('CSP_DEFAULT_SRC', default=CSP_DEFAULT)

--- a/network-api/app/networkapi/settings.py
+++ b/network-api/app/networkapi/settings.py
@@ -132,7 +132,9 @@ MIDDLEWARE_CLASSES = [
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+
     'corsheaders.middleware.CorsMiddleware',
+    'csp.middleware.CSPMiddleware',
 
     'mezzanine.core.request.CurrentRequestMiddleware',
     'mezzanine.core.middleware.RedirectFallbackMiddleware',
@@ -355,6 +357,28 @@ else:
     CORS_ORIGIN_WHITELIST = env('CORS_WHITELIST')
     CORS_ORIGIN_REGEX_WHITELIST = env('CORS_REGEX_WHITELIST')
 
+# CSP
+CSP_DEFAULT = (
+    'self',
+    'localhost:8000',
+    'test.example.com:8000',
+)
+
+CSP_DEFAULT_SRC = env('CSP_DEFAULT_SRC', default=CSP_DEFAULT)
+CSP_SCRIPT_SRC = env('CSP_SCRIPT_SRC', default=CSP_DEFAULT)
+CSP_IMG_SRC = env('CSP_IMG_SRC', default=CSP_DEFAULT)
+CSP_OBJECT_SRC = env('CSP_OBJECT_SRC', default=None)
+CSP_MEDIA_SRC = env('CSP_MEDIA_SRC', default=None)
+CSP_FRAME_SRC = env('CSP_FRAME_SRC', default=None)
+CSP_FONT_SRC = env('CSP_FONT_SRC', default=CSP_DEFAULT)
+CSP_CONNECT_SRC = env('CSP_CONNECT_SRC', default=None)
+CSP_STYLE_SRC = env('CSP_STYLE_SRC', default=CSP_DEFAULT)
+CSP_BASE_URI = env('CSP_BASE_URI', default=None)
+CSP_CHILD_SRC = env('CSP_CHILD_SRC', default=None)
+CSP_FRAME_ANCESTORS = env('CSP_FRAME_ANCESTORS', default=None)
+CSP_FORM_ACTION = env('CSP_FORM_ACTION', default=None)
+CSP_SANDBOX = env('CSP_SANDBOX', default=None)
+CSP_REPORT_URI = env('CSP_REPORT_URI', default=None)
 
 # Security
 SECURE_BROWSER_XSS_FILTER = env('XSS_PROTECTION')

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,9 @@ Pillow==4.0.0
 # CORS
 django-cors-headers==2.0.2
 
+# CSP
+django-csp==3.3
+
 # Admin sort models
 django-admin-sortable==2.1.0
 


### PR DESCRIPTION
This PR adds CSP configuration to the standard Django settings.py file by using the django-csp middleware in combination with environment variables for each separate content category in the CSP specification.

Right now this PR only has the bare minimum in terms of default values for development, but this can be changed to the exact set we need either before landing, or as part of fast follow-up.

This PR closes https://github.com/mozilla/network/issues/679