### PR TITLE
bringing over missing commit from legacy network-api repo

### DIFF
--- a/network-api/app/networkapi/static/js/admin/page_tree.js
+++ b/network-api/app/networkapi/static/js/admin/page_tree.js
@@ -102,11 +102,11 @@ jQuery(function($) {
     // The `connectWith` option needs to be set separately to get
     // around a performance bug with `sortable`.
 
-// ANOTHER CHANGE IS THAT WE'RE USING SORTABLE, NOT NESTEDSORTABLE,
-// BECAUSE WE DON'T WANT TO NEST PAGES INSIDE OF PAGES. THAT'S MADNESS
-//
-//    var $tree = $('#tree > ol').nestedSortable({
-    var $tree = $('#tree > ol').sortable({
+    var $tree = $('#tree > ol').nestedSortable({
+        // override: start #623
+        protectRoot: true,
+        maxLevels: 3,
+        // override: stop #623
         handle: '.ordering',
         opacity: 0.5,
         stop: updateOrdering,

--- a/network-api/app/networkapi/templates/pages/menus/admin.html
+++ b/network-api/app/networkapi/templates/pages/menus/admin.html
@@ -36,7 +36,14 @@
                         <img src="{% static settings.MEZZANINE_ADMIN_PREFIX|add:"img/admin/arrow-up.gif" %}">
                         <img src="{% static settings.MEZZANINE_ADMIN_PREFIX|add:"img/admin/arrow-down.gif" %}">
                     </span>
+
+                    <!-- override: start #623 -->
+                    {% if page.branch_level == 1 %}
+                        <a href="/admin/landingpage/landingpage/add/?parent={{ page.id }}">Add sub-page</a>
+                    {% endif %}
+                    <!-- override: stop #623 -->
                 {% endif %}
+
             {% else %}
             <span class="uneditable">{{ page.title.strip }}</span>
             {% endif %}


### PR DESCRIPTION
Trying to bring over missing updates made to the standalone `network-api` repo...

https://github.com/mozilla/network-api/commit/65a316c899f97127e9a29bf66e46c60bfe3f2a12