### PR TITLE
fixing path for .env

### DIFF
--- a/network-api/app/networkapi/settings.py
+++ b/network-api/app/networkapi/settings.py
@@ -48,8 +48,8 @@ env = environ.Env(
 )
 
 # Read in the environment
-if os.path.exists('.env') is True:
-    environ.Env.read_env('.env')
+if os.path.exists('../.env') is True:
+    environ.Env.read_env('../.env')
 else:
     environ.Env.read_env()
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "optimize:jpg": "find source/images -type f -name '*.jpg' -print0 | xargs -0 -n 1 -P 6 -I '{}' guetzli --quality 93 '{}' '{}'",
     "optimize:png": "find source/images -type f -name '*.png' -print0 | xargs -0 -n 1 -P 6 optipng",
     "optimize": "run-p optimize:**",
-    "server": "source network-api/venv/bin/activate && python network-api/app/manage.py runserver",
+    "server": "cd network-api && source venv/bin/activate && python app/manage.py runserver",
     "start": "npm i && npm run build-uncompressed && run-p server watch:**",
     "test:eslint": "eslint --config ./.eslintrc.yaml scripts/**/*.js source/js/**/*.js source/js/components/**/*.jsx",
     "test:json": "ajv validate -s source/json/people.schema.json -d source/json/temp/people.json && ajv validate -s source/json/news.schema.json -d source/json/temp/news.json && ajv validate -s source/json/upcoming.schema.json -d source/json/temp/upcoming.json && ajv validate -s source/json/highlights.schema.json -d source/json/temp/highlights.json",


### PR DESCRIPTION
When I just tried to run a migration with `python app/manage.py migrate` I had to copy the `.env` from the root into `network-api` for it to work.

This should fix that...