### PR TITLE
Add a CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,7 @@
+# global owners
+
+* @mozilla/mofo-eng
+
+# Default reviewers
+
+* @alanmoo @cadecairos @gvn @pomax @gideonthomas


### PR DESCRIPTION
Added myself, @alanmoo, @Pomax, @gvn, and @gideonthomas as code owners, based on commit activity graphs for this repo. 

I think a global owner declaration might be redundant, now that I stop to look at it. I will remove it (or we can just manage code ownership and reviews using a team...?)

fixes #726 