### PR TITLE
Expose homepage data on the API

### DIFF
--- a/network-api/app/networkapi/homepage/serializers.py
+++ b/network-api/app/networkapi/homepage/serializers.py
@@ -1,0 +1,86 @@
+from rest_framework import serializers
+
+from networkapi.homepage.models import (
+    Homepage,
+    HomepageLeaders,
+    HomepageNews,
+    HomepageHighlights,
+)
+from networkapi.people.serializers import PersonSerializer
+from networkapi.news.serializers import NewsSerializer
+from networkapi.highlights.serializers import HighlightSerializer
+
+
+def serialize_relation(
+    homepage_obj,
+    through_model,
+    related_field_name,
+    related_serializer,
+):
+    """
+    Returns a list of serialized related objects that are related to the
+    homepage
+
+    :param homepage_obj: is the instance that we want to seialize related
+    objects for
+    :param through_model: is the model class that represents the relation (not
+    the model of the related object itself)
+    :param related_field_name: is the field name on the `through_model` that
+    is a foreign key pointing to the model related to the homepage
+    :param related_serializer: is the serializer class to use to serialize the
+    related model instance
+    :returns: list of serialized related model instances
+    """
+
+    related_objs = []
+    relation = (
+        through_model.objects
+        .select_related(related_field_name)
+        .order_by('_order')
+        .filter(homepage=homepage_obj)
+    )
+
+    for related_field in relation:
+        related_objs.append(getattr(related_field, related_field_name))
+
+    return related_serializer(related_objs, many=True).data
+
+
+class HomepageSerializer(serializers.ModelSerializer):
+    """
+    Serializes a single (the only) homepage object including its
+    related models using their default serializers
+    """
+    leaders = serializers.SerializerMethodField()
+
+    def get_leaders(self, instance):
+        return serialize_relation(
+            instance,
+            HomepageLeaders,
+            'leader',
+            PersonSerializer
+        )
+
+    highlights = serializers.SerializerMethodField()
+
+    def get_highlights(self, instance):
+        return serialize_relation(
+            instance,
+            HomepageHighlights,
+            'highlights',
+            HighlightSerializer
+        )
+
+    news = serializers.SerializerMethodField()
+
+    def get_news(self, instance):
+        return serialize_relation(
+            instance,
+            HomepageNews,
+            'news',
+            NewsSerializer
+        )
+
+    class Meta:
+        model = Homepage
+        fields = ('leaders', 'news', 'highlights',)

--- a/network-api/app/networkapi/homepage/urls.py
+++ b/network-api/app/networkapi/homepage/urls.py
@@ -1,0 +1,7 @@
+from django.conf.urls import url
+
+from networkapi.homepage.views import HomepageView
+
+urlpatterns = [
+    url('^$', HomepageView.as_view(), name='homepage'),
+]

--- a/network-api/app/networkapi/homepage/views.py
+++ b/network-api/app/networkapi/homepage/views.py
@@ -1,3 +1,23 @@
-# from django.shortcuts import render
+from rest_framework.views import APIView
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from django.http import Http404
 
-# Create your views here.
+from networkapi.homepage.models import Homepage
+from networkapi.homepage.serializers import HomepageSerializer
+
+
+class HomepageView(APIView):
+    """
+    A view that permits a GET to receive the related models on the homepage
+    """
+    permission_classes = (AllowAny,)
+
+    def get(self, request, format=None):
+        homepage = Homepage.objects.last()
+
+        if homepage is None:
+            raise Http404('Homepage has not been created yet')
+
+        serializer = HomepageSerializer(homepage)
+        return Response(serializer.data)

--- a/network-api/app/networkapi/urls.py
+++ b/network-api/app/networkapi/urls.py
@@ -32,6 +32,7 @@ urlpatterns = list(filter(None, [
     url(r'^api/news/', include('networkapi.news.urls')),
     url(r'^api/milestones/', include('networkapi.milestones.urls')),
     url(r'^api/highlights/', include('networkapi.highlights.urls')),
+    url(r'^api/homepage/', include('networkapi.homepage.urls')),
     url(r'^$', mezzanine.pages.views.page, {'slug': '/'}, name='home'),
     url(r'^', include('mezzanine.urls')),
 ]))


### PR DESCRIPTION
Fixes #658. 

The data returned by `/api/homepage` looks like:
```js
{
  "leaders": [{
    "name": <string>,
    "role": <string>,
    "location": <string>,
    "image": <string url>,
    "links": {
      "twitter": <string url>,
      "interview": <string url>,
      "linkedIn": <string url>
    },
    "featured": <boolean>, // ignore this for now, will remove later
    "bio": <string>,
    "quote": <string>,
    "affiliations": <array of strings>,
    "internet_health_issues": <array of strings>,
    "partnership_logo": <string url>
  }, ...usually two more],
  
  "news": [{
    "headline": <string>,
    "outlet": <string>,
    "date": "yyyy-mm-dd",
    "link": <string url>,
    "excerpt": <string>,
    "author": <string>,
    "glyph": <string url>,
    "thumbnail": <string url>,
    "is_video": <boolean>, // should be true for the first element
    "featured": <boolean>
  }, ...usually three more],
  
  "highlights": [{
    "id": <integer>,
    "title": <string>,
    "description": <string>,
    "link_url": <string url>,
    "link_label": <string>,
    "image": <string url>,
    "footer": <string>
  }, ...usually two more]
}
```

@gvn, does the above payload look ok or do you need more data?