### PR TITLE
add the AWS location to the absolute glyph URL

### DIFF
--- a/network-api/app/networkapi/news/serializers.py
+++ b/network-api/app/networkapi/news/serializers.py
@@ -12,8 +12,9 @@ class NewsSerializer(serializers.ModelSerializer):
     def get_glyph(self, instance):
         # Remote hosted? Return the remote URL
         if settings.USE_S3:
-            return "{host}{glyph}".format(
+            return "{host}{bin}{glyph}".format(
                 host=settings.MEDIA_URL,
+                bin=settings.AWS_LOCATION + '/',
                 glyph=instance.glyph
             )
 


### PR DESCRIPTION
closes https://github.com/mozilla/network/issues/769 (or, should) by working in the correct bin name.

This turns the current bad glyph location (e.g. https://assets.mofostaging.net/images/news/the-woman-whose-phone-misdiagnosed-hiv_1492475903.svg) into a working glyph location (e.g. https://assets.mofostaging.net/network/images/news/the-woman-whose-phone-misdiagnosed-hiv_1492475903.svg)