### PR TITLE
Updating python version in runtime.txt

### DIFF
--- a/network-api/runtime.txt
+++ b/network-api/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.0
+python-3.6.2


### PR DESCRIPTION
While looking at build logs from Heroku, I saw this:
```
-----> Python app detected

 !     The latest version of Python 3 is python-3.6.2 (you are using python-3.6.0, which is unsupported).

 !     We recommend upgrading by specifying the latest version (python-3.6.2).

       Learn More: https://devcenter.heroku.com/articles/python-runtimes
```

I bumped python to 3.6.2, so Heroku should be happy now 😉 