### PR TITLE
Add middleware (off by default) for redirecting requests to the target domain of the foundation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,10 @@ Production URL is [network.mozilla.org](https://network.mozilla.org)
 
 A healthcheck route that indicates the most recent commit and other useful information is accessible on `/healthcheck.html`.
 
+##### Domain Redirect
+
+Enable domain redirection by setting `DOMAIN_REDIRECT_MIDDLWARE_ENABLED` to `True`. This will enable a middleware function that checks every request, and return a 307 redirect to `TARGET_DOMAIN` if the host header does not match it.
+
 ---
 
 ### Environment Variables

--- a/network-api/app/networkapi/settings.py
+++ b/network-api/app/networkapi/settings.py
@@ -27,6 +27,7 @@ env = environ.Env(
     AWS_LOCATION=(str, ''),
     BUILD_DEBOUNCE_SECONDS=(int, 300),
     BUILD_THROTTLE_SECONDS=(int, 900),
+    DOMAIN_REDIRECT_MIDDLWARE_ENABLED=(bool, False),
     HEROKU_APP_NAME=(str, ''),
     GITHUB_PROJECT_MASTER_TAR_URL=(str, ''),
     HEROKU_API_TOKEN=(str, ''),
@@ -47,7 +48,7 @@ env = environ.Env(
     SOCIAL_AUTH_GOOGLE_OAUTH2_KEY=(str, None),
     SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET=(str, None),
     SSL_REDIRECT=bool,
-    TARGET_DOMAIN=(str, ''),
+    TARGET_DOMAIN=(str, None),
     USE_S3=(bool, True),
     USE_X_FORWARDED_HOST=(bool, False),
     XSS_PROTECTION=bool,
@@ -72,6 +73,10 @@ DEBUG = FILEBROWSER_DEBUG = env('DEBUG')
 
 # This should only be needed in Heroku review apps
 LOAD_FIXTURE = env('LOAD_FIXTURE')
+
+# Force permanent redirects to the domain specified in TARGET_DOMAIN
+DOMAIN_REDIRECT_MIDDLWARE_ENABLED = env('DOMAIN_REDIRECT_MIDDLWARE_ENABLED')
+TARGET_DOMAIN = env('TARGET_DOMAIN')
 
 if env('FILEBROWSER_DEBUG') or DEBUG != env('FILEBROWSER_DEBUG'):
     FILEBROWSER_DEBUG = env('FILEBROWSER_DEBUG')
@@ -136,7 +141,9 @@ INSTALLED_APPS = list(filter(None, [
     'networkapi.milestones',
 ]))
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
+    'networkapi.utility.middleware.TargetDomainRedirectMiddleware',
+
     'mezzanine.core.middleware.UpdateCacheMiddleware',
 
     'django.middleware.security.SecurityMiddleware',

--- a/network-api/app/networkapi/utility/middleware.py
+++ b/network-api/app/networkapi/utility/middleware.py
@@ -13,7 +13,6 @@ class TargetDomainRedirectMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        # print('in middleware')
         if settings.DOMAIN_REDIRECT_MIDDLWARE_ENABLED:
             request_host = request.META['HTTP_HOST']
 

--- a/network-api/app/networkapi/utility/middleware.py
+++ b/network-api/app/networkapi/utility/middleware.py
@@ -1,7 +1,7 @@
 from django.http.response import HttpResponseRedirectBase
 from mezzanine.conf import settings
 
-target_domain = settings.TARGET_DOMAIN
+hostname = settings.TARGET_DOMAIN
 
 
 class HttpResponseTemporaryRedirect(HttpResponseRedirectBase):
@@ -16,13 +16,13 @@ class TargetDomainRedirectMiddleware:
         if settings.DOMAIN_REDIRECT_MIDDLWARE_ENABLED:
             request_host = request.META['HTTP_HOST']
 
-            if request_host != target_domain:
+            if request_host != hostname:
                 protocol = 'https' if request.is_secure() else 'http'
 
-                redirect_url = '{}://{}{}'.format(
-                    protocol,
-                    target_domain,
-                    request.get_full_path()
+                redirect_url = '{protocol}://{hostname}{path}'.format(
+                    protocol=protocol,
+                    hostname=hostname,
+                    path=request.get_full_path()
                 )
 
                 return HttpResponseTemporaryRedirect(redirect_url)

--- a/network-api/app/networkapi/utility/middleware.py
+++ b/network-api/app/networkapi/utility/middleware.py
@@ -1,0 +1,31 @@
+from django.http.response import HttpResponseRedirectBase
+from mezzanine.conf import settings
+
+target_domain = settings.TARGET_DOMAIN
+
+
+class HttpResponseTemporaryRedirect(HttpResponseRedirectBase):
+    status_code = 307
+
+
+class TargetDomainRedirectMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        # print('in middleware')
+        if settings.DOMAIN_REDIRECT_MIDDLWARE_ENABLED:
+            request_host = request.META['HTTP_HOST']
+
+            if request_host != target_domain:
+                protocol = 'https' if request.is_secure() else 'http'
+
+                redirect_url = '{}://{}{}'.format(
+                    protocol,
+                    target_domain,
+                    request.get_full_path()
+                )
+
+                return HttpResponseTemporaryRedirect(redirect_url)
+
+        return self.get_response(request)


### PR DESCRIPTION
This will allow us to easily redirect network.mozilla.org to foundation.mozilla.org in perpetuity, and continue reaping the benefits of Lets Encrypt for HTTPS on `network.mozilla.org`